### PR TITLE
Add mMixedQuantities to all systems

### DIFF
--- a/classes/System/DoubleFourBarLinkage.m
+++ b/classes/System/DoubleFourBarLinkage.m
@@ -29,6 +29,7 @@ classdef DoubleFourBarLinkage < System
             self.MASS = CONFIG.MASS;
             % 3 coordinates of center of mass + 3*3 director coordinates
             self.nDOF = self.nBODIES*6;
+            self.mMixedQuantities = 0;
             % ext. acceleration only acts on center of mass
             self.EXT_ACC = [CONFIG.EXT_ACC; zeros(4, 1); CONFIG.EXT_ACC; zeros(4, 1); CONFIG.EXT_ACC; zeros(4, 1); CONFIG.EXT_ACC; zeros(4, 1); CONFIG.EXT_ACC; zeros(4, 1)];
 

--- a/classes/System/DoublePendulum.m
+++ b/classes/System/DoublePendulum.m
@@ -17,6 +17,7 @@ classdef DoublePendulum < System
             % both masses in a vector
             self.MASS = CONFIG.MASS;
             self.nDOF = self.nBODIES * CONFIG.DIM;
+            self.mMixedQuantities = 0;
             self.MASS_MAT = diag([repmat(self.MASS(1), self.DIM, 1); repmat(self.MASS(2), self.DIM, 1)]);
             self.EXT_ACC = repmat(CONFIG.EXT_ACC, self.nBODIES, 1);
             %length of 1st rod

--- a/classes/System/FourParticleSystem.m
+++ b/classes/System/FourParticleSystem.m
@@ -32,6 +32,7 @@ classdef FourParticleSystem < System
             self.DIM = CONFIG.DIM;
             self.MASS = CONFIG.MASS;
             self.nDOF = self.nBODIES * CONFIG.DIM;
+            self.mMixedQuantities = 0;
             self.MASS_MAT = diag([repmat(self.MASS(1), self.DIM, 1); repmat(self.MASS(2), self.DIM, 1); repmat(self.MASS(3), self.DIM, 1); repmat(self.MASS(4), self.DIM, 1)]);
             self.EXT_ACC = repmat(CONFIG.EXT_ACC, self.nBODIES, 1);
 

--- a/classes/System/HeavyTop.m
+++ b/classes/System/HeavyTop.m
@@ -25,6 +25,7 @@ classdef HeavyTop < System
             self.MASS = CONFIG.MASS;
             % 3 coordinates of center of mass + 3*3 director coordinates
             self.nDOF = 12;
+            self.mMixedQuantities = 0;
             % ext. acceleration only acts on center of mass
             self.EXT_ACC = [CONFIG.EXT_ACC; zeros(9, 1)];
 

--- a/classes/System/LagrangeTop.m
+++ b/classes/System/LagrangeTop.m
@@ -19,6 +19,7 @@ classdef LagrangeTop < System
             self.MASS = CONFIG.MASS;
             % 3 coordinates of center of mass + 3*3 director coordinates
             self.nDOF = 3;
+            self.mMixedQuantities = 0;
             % ext. acceleration only acts on center of mass
             self.EXT_ACC = [CONFIG.EXT_ACC; zeros(9, 1)];
 

--- a/classes/System/Pendulum.m
+++ b/classes/System/Pendulum.m
@@ -16,6 +16,7 @@ classdef Pendulum < System
             self.MASS = CONFIG.MASS;
             self.MASS_MAT = self.MASS * eye(CONFIG.DIM);
             self.nDOF = self.nBODIES * CONFIG.DIM;
+            self.mMixedQuantities = 0;
             self.EXT_ACC = repmat(CONFIG.EXT_ACC, self.nBODIES, 1);
             self.GEOM(1) = norm(CONFIG.Q_0(1:CONFIG.DIM)); %length of pendulum
             self.nPotentialInvariants = 0;

--- a/classes/System/PendulumMinCoord.m
+++ b/classes/System/PendulumMinCoord.m
@@ -18,6 +18,7 @@ classdef PendulumMinCoord < System
             self.DIM = CONFIG.DIM;
             self.MASS = CONFIG.MASS;
             self.nDOF = 2;
+            self.mMixedQuantities = 0;
             self.MASS_MAT = [];
             self.EXT_ACC = CONFIG.EXT_ACC;
 

--- a/classes/System/RedundantTwoMassSpringSystem.m
+++ b/classes/System/RedundantTwoMassSpringSystem.m
@@ -25,6 +25,7 @@ classdef RedundantTwoMassSpringSystem < System
             m1 = CONFIG.MASS(1);
             m2 = CONFIG.MASS(2);
             self.nDOF = 3;
+            self.mMixedQuantities = 0;
             self.MASS_MAT = [m1 ,0, 0;
                              0, m2, m2;
                              0, m2, m2];
@@ -40,7 +41,6 @@ classdef RedundantTwoMassSpringSystem < System
 
             self.nPotentialInvariants = 2;
             self.nConstraintInvariants = 1;
-            self.mMixedQuantities = 0;
             self.DISS_MAT = zeros(3,3);
 
         end

--- a/classes/System/RigidBodyMoving.m
+++ b/classes/System/RigidBodyMoving.m
@@ -24,6 +24,7 @@ classdef RigidBodyMoving < System
             self.MASS = CONFIG.MASS;
             % 3 coordinates of center of mass + 3*3 director coordinates
             self.nDOF = 12;
+            self.mMixedQuantities = 0;
             % ext. acceleration only acts on center of mass
             self.EXT_ACC = [CONFIG.EXT_ACC; zeros(9, 1)];
             % 3 constraints of orthogonality of directors, 3 constraints

--- a/classes/System/SpringPendulumPolar.m
+++ b/classes/System/SpringPendulumPolar.m
@@ -18,6 +18,7 @@ classdef SpringPendulumPolar < System
             self.DIM = CONFIG.DIM;
             self.MASS = CONFIG.MASS;
             self.nDOF = 3;
+            self.mMixedQuantities = 0;
             self.MASS_MAT = [];
             self.EXT_ACC = CONFIG.EXT_ACC;
 

--- a/classes/System/TwoMassSpringSystem.m
+++ b/classes/System/TwoMassSpringSystem.m
@@ -23,6 +23,7 @@ classdef TwoMassSpringSystem < System
             self.DIM = CONFIG.DIM;
             self.MASS = CONFIG.MASS;
             self.nDOF = 2;
+            self.mMixedQuantities = 0;
             self.MASS_MAT = diag(CONFIG.MASS);
             self.EXT_ACC = [];
 


### PR DESCRIPTION
Cool project!

I'm on Win11 and Matlab 22b.

I had an issue when running `start_metis_single_analysis.m` for most systems except for `SpringPendulum`.
The error I got was:
```
Operands to the logical AND (&&) and OR (||) operators must be convertible to logical scalar values. Use the ANY
or ALL functions to reduce operands to logical scalar values.

Error in Postprocess/compute (line 99)
            if this_system.mMixedQuantities > 0 && this_simulation.INDI_VELO

Error in start_metis_single_analysis (line 39)
simulation = postprocess.compute(system, simulation, integrator);
```
Seems to me like the error occurs if `this_system.mMixedQuantities` isn't set.
So I just set this value to zero for all systems (except for `SpringPendulum`).

If that's not how you would fix it, feel free to close this PR.